### PR TITLE
Fix mkdocs deprecated settings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,15 +22,16 @@ markdown_extensions:
   - pymdownx.snippets:
       check_paths: true
 
+watch:
+  - languageassistant
+
 plugins:
   - search:
   - mkdocstrings:
       default_handler: python
       handlers:
         python:
-          rendering:
+          options:
             show_signature_annotations: true
             show_source: true
             show_submodules: true
-      watch:
-        - languageassistant


### PR DESCRIPTION
Serving the documentation throws deprecation errors from the mkdocstrings watch and rendering flags.

This resolves those errors by using mkdocs' built-in watch feature and replaces `rendering` with `options` as suggested by mkdocs.
