### PR TITLE
Refactor agent file structure

### DIFF
--- a/languageassistant/agents/conversation/__init__.py
+++ b/languageassistant/agents/conversation/__init__.py
@@ -1,8 +1,7 @@
 """Target language conversation agent"""
 
-from languageassistant.agents.conversation.base import ConversationAgent
-from languageassistant.agents.conversation.conversation_chain import (
-    load_conversation_agent,
-)
+from languageassistant.agents.conversation.agent import ConversationAgent
+from languageassistant.agents.conversation.base import BaseConversationAgent
+from languageassistant.agents.conversation.loader import load_conversation_agent
 
-__all__ = ["ConversationAgent", "load_conversation_agent"]
+__all__ = ["BaseConversationAgent", "ConversationAgent", "load_conversation_agent"]

--- a/languageassistant/agents/conversation/agent.py
+++ b/languageassistant/agents/conversation/agent.py
@@ -1,0 +1,50 @@
+from typing import Dict, List, Optional
+
+from langchain.callbacks.manager import Callbacks
+from langchain.chains import LLMChain
+
+from languageassistant.agents.conversation.base import BaseConversationAgent
+
+GREETING = (
+    "What should I know before we start the conversation? Any useful words or phrases?"
+)
+
+
+def validate_inputs(inputs: Dict[str, str]) -> None:
+    assert "language" in inputs, "Must provide target language for conversation agent"
+    assert (
+        "proficiency" in inputs
+    ), "Must provide user target language proficiency for conversation agent"
+    assert "topic" in inputs, "Must provide topic for conversation agent"
+
+
+class ConversationAgent(BaseConversationAgent):
+    llm_chain: LLMChain
+    stop: Optional[List] = None
+
+    def greet(self, inputs: Dict[str, str], callbacks: Callbacks = None) -> str:
+        """Start a new conversation about a topic."""
+        _inputs = inputs.copy()
+        validate_inputs(inputs)
+        if "human_input" not in _inputs:
+            _inputs["human_input"] = GREETING
+        response = self.speak(_inputs)
+        return response
+
+    def speak(self, inputs: Dict[str, str], callbacks: Callbacks = None) -> str:
+        """Given input, create reply.
+        inputs: dict {
+        langauge: target language (optional),
+        proficiency: user proficiency with target language (optional)
+        topic: the topic to discuss (optional),
+        input: the current user input in the conversation
+        """
+        _inputs = inputs.copy()
+        validate_inputs(_inputs)
+        assert (
+            "human_input" in _inputs
+        ), "Must provide human input for conversation chain"
+        llm_response = self.llm_chain.run(
+            **_inputs, stop=self.stop, callbacks=callbacks
+        )
+        return llm_response

--- a/languageassistant/agents/conversation/base.py
+++ b/languageassistant/agents/conversation/base.py
@@ -1,24 +1,13 @@
-from abc import abstractmethod
-from typing import Dict, List, Optional
+from abc import ABC, abstractmethod
+from typing import Dict
 
 from langchain.callbacks.manager import Callbacks
-from langchain.chains.llm import LLMChain
 from pydantic import BaseModel
 
-GREETING = (
-    "What should I know before we start the conversation? Any useful words or phrases?"
-)
 
+class BaseConversationAgent(BaseModel, ABC):
+    """Abstract base conversation agent class"""
 
-def validate_inputs(inputs: Dict[str, str]) -> None:
-    assert "language" in inputs, "Must provide target language for conversation agent"
-    assert (
-        "proficiency" in inputs
-    ), "Must provide user target language proficiency for conversation agent"
-    assert "topic" in inputs, "Must provide topic for conversation agent"
-
-
-class BaseConversationAgent(BaseModel):
     @abstractmethod
     def greet(self, inputs: Dict[str, str], callbacks: Callbacks = None) -> str:
         """Start a new conversation about a topic."""
@@ -26,35 +15,3 @@ class BaseConversationAgent(BaseModel):
     @abstractmethod
     def speak(self, inputs: Dict[str, str], callbacks: Callbacks = None) -> str:
         """Single atomic reply to last human message."""
-
-
-class ConversationAgent(BaseConversationAgent):
-    llm_chain: LLMChain
-    stop: Optional[List] = None
-
-    def greet(self, inputs: Dict[str, str], callbacks: Callbacks = None) -> str:
-        """Start a new conversation about a topic."""
-        _inputs = inputs.copy()
-        validate_inputs(inputs)
-        if "human_input" not in _inputs:
-            _inputs["human_input"] = GREETING
-        response = self.speak(_inputs)
-        return response
-
-    def speak(self, inputs: Dict[str, str], callbacks: Callbacks = None) -> str:
-        """Given input, create reply.
-        inputs: dict {
-        langauge: target language (optional),
-        proficiency: user proficiency with target language (optional)
-        topic: the topic to discuss (optional),
-        input: the current user input in the conversation
-        """
-        _inputs = inputs.copy()
-        validate_inputs(_inputs)
-        assert (
-            "human_input" in _inputs
-        ), "Must provide human input for conversation chain"
-        llm_response = self.llm_chain.run(
-            **_inputs, stop=self.stop, callbacks=callbacks
-        )
-        return llm_response

--- a/languageassistant/agents/conversation/loader.py
+++ b/languageassistant/agents/conversation/loader.py
@@ -3,7 +3,7 @@ from langchain.chains import LLMChain
 from langchain.memory import ConversationBufferMemory
 from langchain.prompts.prompt import PromptTemplate
 
-from languageassistant.agents.conversation import ConversationAgent
+from languageassistant.agents.conversation.agent import ConversationAgent
 
 PROMPT_TEMPLATE = (
     "Assistant is a native {language} language teacher."

--- a/languageassistant/agents/planner/__init__.py
+++ b/languageassistant/agents/planner/__init__.py
@@ -2,6 +2,20 @@
 Lesson planning agent.
 Modified version of langchain chat_planner
 """
-from languageassistant.agents.planner.planner_chain import load_lesson_planner
+from languageassistant.agents.planner.agent import LessonPlannerAgent
+from languageassistant.agents.planner.base import BasePlannerAgent
+from languageassistant.agents.planner.loader import load_lesson_planner
+from languageassistant.agents.planner.schema import (
+    BaseLessonOutputParser,
+    Lesson,
+    LessonOutputParser,
+)
 
-__all__ = ["load_lesson_planner"]
+__all__ = [
+    "BaseLessonOutputParser",
+    "BasePlannerAgent",
+    "LessonOutputParser",
+    "LessonPlannerAgent",
+    "Lesson",
+    "load_lesson_planner",
+]

--- a/languageassistant/agents/planner/agent.py
+++ b/languageassistant/agents/planner/agent.py
@@ -1,0 +1,21 @@
+"""Lesson planning agent implementation"""
+from typing import Any, List, Optional
+
+from langchain.callbacks.manager import Callbacks
+from langchain.chains import LLMChain
+
+from languageassistant.agents.planner.base import BasePlannerAgent
+from languageassistant.agents.planner.schema import Lesson, LessonOutputParser
+
+
+class LessonPlannerAgent(BasePlannerAgent):
+    """LLM agent for planning language lessons"""
+
+    llm_chain: LLMChain
+    output_parser: LessonOutputParser
+    stop: Optional[List] = None
+
+    def plan(self, inputs: dict, callbacks: Callbacks = None, **kwargs: Any) -> Lesson:
+        """Given input, decided what to do."""
+        llm_response = self.llm_chain.run(**inputs, stop=self.stop, callbacks=callbacks)
+        return self.output_parser.parse(llm_response)

--- a/languageassistant/agents/planner/base.py
+++ b/languageassistant/agents/planner/base.py
@@ -1,25 +1,16 @@
-from abc import abstractmethod
-from typing import Any, List, Optional
+"""Base abstract planner classes"""
+from abc import ABC, abstractmethod
+from typing import Any
 
 from langchain.callbacks.manager import Callbacks
-from langchain.chains.llm import LLMChain
 from pydantic import BaseModel
 
-from languageassistant.agents.planner.schema import Lesson, LessonOutputParser
+from languageassistant.agents.planner.schema import Lesson
 
 
-class BasePlanner(BaseModel):
+class BasePlannerAgent(BaseModel, ABC):
+    """Abstract base planner agent class"""
+
     @abstractmethod
     def plan(self, inputs: dict, callbacks: Callbacks = None, **kwargs: Any) -> Lesson:
         """Given input, decided what to do."""
-
-
-class LessonPlanner(BasePlanner):
-    llm_chain: LLMChain
-    output_parser: LessonOutputParser
-    stop: Optional[List] = None
-
-    def plan(self, inputs: dict, callbacks: Callbacks = None, **kwargs: Any) -> Lesson:
-        """Given input, decided what to do."""
-        llm_response = self.llm_chain.run(**inputs, stop=self.stop, callbacks=callbacks)
-        return self.output_parser.parse(llm_response)

--- a/languageassistant/agents/planner/loader.py
+++ b/languageassistant/agents/planner/loader.py
@@ -1,12 +1,10 @@
-import re
-
 from langchain.base_language import BaseLanguageModel
 from langchain.chains import LLMChain
 from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain.schema import SystemMessage
 
-from languageassistant.agents.planner.base import LessonPlanner
-from languageassistant.agents.planner.schema import Lesson, LessonOutputParser
+from languageassistant.agents.planner.agent import LessonPlannerAgent
+from languageassistant.agents.planner.schema import LessonOutputParser
 
 SYSTEM_PROMPT = (
     "Please output the requested list of broad lesson topics starting with the header 'Topics:' "
@@ -25,15 +23,9 @@ HUMAN_TEMPLATE = (
 )
 
 
-class LessonPlanningOutputParser(LessonOutputParser):
-    def parse(self, text: str) -> Lesson:
-        topics = [v.strip() for v in re.split(r"\n\d+\. ", text)[1:]]
-        return Lesson(topics=topics)
-
-
 def load_lesson_planner(
     llm: BaseLanguageModel, system_prompt: str = SYSTEM_PROMPT, verbose: bool = False
-) -> LessonPlanner:
+) -> LessonPlannerAgent:
     prompt_template = ChatPromptTemplate.from_messages(
         [
             SystemMessage(content=system_prompt),
@@ -41,8 +33,8 @@ def load_lesson_planner(
         ]
     )
     llm_chain = LLMChain(llm=llm, prompt=prompt_template, verbose=verbose)
-    return LessonPlanner(
+    return LessonPlannerAgent(
         llm_chain=llm_chain,
-        output_parser=LessonPlanningOutputParser(),
+        output_parser=LessonOutputParser(),
         stop=["<END_OF_LIST>"],
     )

--- a/languageassistant/agents/planner/schema.py
+++ b/languageassistant/agents/planner/schema.py
@@ -1,4 +1,6 @@
-from abc import abstractmethod
+"""Lesson parsing and formatting schemas"""
+import re
+from abc import ABC, abstractmethod
 from typing import List
 
 from langchain.schema import BaseOutputParser
@@ -11,13 +13,35 @@ class Lesson(BaseModel):
     topics: List[str]
 
     def __str__(self) -> str:
+        """Converts the lesson to a printable string"""
         lesson = ""
         for i, topic in enumerate(self.topics):
             lesson += f"{i + 1}. {topic}\n"
         return lesson
 
 
-class LessonOutputParser(BaseOutputParser):
+class BaseLessonOutputParser(BaseOutputParser, ABC):
+    """Base lesson plan output parser class"""
+
     @abstractmethod
     def parse(self, text: str) -> Lesson:
         """Parse into a lesson with a list of topics."""
+
+
+class LessonOutputParser(BaseLessonOutputParser):
+    """Parses LLM lesson into a Lesson object"""
+
+    def parse(self, text: str) -> Lesson:
+        """Instructions on how the LLM output should be formatted."""
+        topics = [v.strip() for v in re.split(r"\n\d+\. ", text)[1:]]
+        return Lesson(topics=topics)
+
+    def get_format_instructions(self) -> str:
+        """Instructions on how the LLM output should be formatted."""
+        return (
+            "Please output the requested list of broad lesson topics starting with the header 'Topics:' "
+            "and then followed by a numbered list of topics. "
+            "Please include enough general topics that a language teacher could "
+            "effectively teach the language for the given skill level. "
+            "At the end of your list of topics, say '<END_OF_LIST>'"
+        )

--- a/languageassistant/assistant.py
+++ b/languageassistant/assistant.py
@@ -7,11 +7,15 @@ from langchain.base_language import BaseLanguageModel
 from langchain.chat_models import ChatOpenAI
 from pydantic import BaseModel
 
-from languageassistant.agents.conversation import load_conversation_agent
-from languageassistant.agents.conversation.base import BaseConversationAgent
-from languageassistant.agents.planner import load_lesson_planner
-from languageassistant.agents.planner.base import BasePlanner
-from languageassistant.agents.planner.schema import Lesson
+from languageassistant.agents.conversation import (
+    BaseConversationAgent,
+    load_conversation_agent,
+)
+from languageassistant.agents.planner import (
+    BasePlannerAgent,
+    Lesson,
+    load_lesson_planner,
+)
 from languageassistant.transcriber import Transcriber
 from languageassistant.tts import TTS
 
@@ -24,7 +28,7 @@ class Assistant(BaseModel):
     lesson: Lesson = Lesson(topics=[])
 
     llm: BaseLanguageModel = ChatOpenAI(temperature=0)  # type: ignore[call-arg]
-    lesson_agent: BasePlanner = load_lesson_planner(llm)
+    lesson_agent: BasePlannerAgent = load_lesson_planner(llm)
     conversation_agent: BaseConversationAgent = load_conversation_agent(llm)
     transcriber: Transcriber
     tts: TTS

--- a/tests/unit_tests/test_agents/test_conversation.py
+++ b/tests/unit_tests/test_agents/test_conversation.py
@@ -4,7 +4,7 @@ import pytest
 from langchain.chat_models import ChatOpenAI
 
 from languageassistant.agents.conversation import load_conversation_agent
-from languageassistant.agents.conversation.base import validate_inputs
+from languageassistant.agents.conversation.agent import validate_inputs
 from languageassistant.utils import load_openai_api_key
 
 invalid_openai_api_key = os.getenv("OPENAI_API_KEY") in [None, "", "api_key"]


### PR DESCRIPTION
Instead of having the actual agent implementations in the `base.py` files and the loader in a `{agent}_chain.py` file, I have refactored the agents to have the following structure:

- base.py: abstract base classes
- agent.py: actual agent class implementation
- loader.py: LLM chain loader with prompts
- schema.py (optional): any output/parsing schemas 